### PR TITLE
Make 'invalid tag model' error message more readable

### DIFF
--- a/R/handleRegisterTags.R
+++ b/R/handleRegisterTags.R
@@ -88,7 +88,7 @@ handleRegisterTags = function(j) {
     ## ignore hyphens when matching model
     tmi = match(gsub("-", "", tagModel, perl=TRUE), gsub("-", "", rownames(tagLifespanPars), perl=TRUE))
     if (is.na(tmi)) {
-        errs = c(errs, paste0("Invalid tag model: ", tagModel, "; must be one of:\n", paste(rownames(tagLifespanPars), collapse=", ")))
+        errs = c(errs, paste0("Invalid tag model: ", tagModel, "; must be one of:\n", paste(sort(rownames(tagLifespanPars)), collapse="\n")))
     } else {
         ## fix up any hyphens so upstream recognizes the model string
         tagModel = rownames(tagLifespanPars)[tmi]


### PR DESCRIPTION
Old message looks like this:

Error: Error in h(j): Invalid tag model: NTQB-4-2S; must be one of: NTQB-1-LW, NTQB-1, NTQB-2, NTQB-3-2, NTQB-4-2, NTQB-6-1, NTQB-6-2, NTQBW-3-2, NTQBW-2, NTQBW-4-2, NTQBW-6-2, ANTC-M1-1, ANTC-M2-1, ANTC-M3-1, ANTC-M3-2, ANTC-M4-2, ANTC-M4-2S, ANTC-M4-2L, ANTC-M6-1, ANTC-M6-2, ANTCW-M1-1, ANTCW-M2-1, ANTCW-M3-1, ANTCW-M3-2, ANTCW-M4-2, ANTCW-M4-2S, ANTCW-M4-2L, ANTCW-M6-1, ANTCW-M6-2, ACT-521, ACT-626, ACT-393, NTQB2-1, NTQB2-2, NTQB2-3-2, NTQB2-4-2, NTQB2-4-2S, NTQB2-5-1, NTQB2-6-1, NTQB2-6-2

New message looks like this:

Error: Error in h(j): Invalid tag model: NTQB-4-2S; must be one of:
ACT-393
ACT-521
ACT-626
ANTC-M1-1
ANTC-M2-1
ANTC-M3-1
ANTC-M3-2
ANTC-M4-2
ANTC-M4-2L
ANTC-M4-2S
ANTC-M6-1
ANTC-M6-2
ANTCW-M1-1
ANTCW-M2-1
ANTCW-M3-1
ANTCW-M3-2
ANTCW-M4-2
ANTCW-M4-2L
ANTCW-M4-2S
ANTCW-M6-1
ANTCW-M6-2
NTQB-1
NTQB-1-LW
NTQB-2
NTQB-3-2
NTQB-4-2
NTQB-6-1
NTQB-6-2
NTQB2-1
NTQB2-2
NTQB2-3-2
NTQB2-4-2
NTQB2-4-2S
NTQB2-5-1
NTQB2-6-1
NTQB2-6-2
NTQBW-2
NTQBW-3-2
NTQBW-4-2
NTQBW-6-2